### PR TITLE
Fix: destination view is now added once (was twice)

### DIFF
--- a/GRPushSegue/GRPushSegue.m
+++ b/GRPushSegue/GRPushSegue.m
@@ -26,8 +26,6 @@
     
     NSRect destinationRect = fromViewController.view.frame;
     
-    [fromViewController.view addSubview:viewController.view];
-    
     [NSAnimationContext runAnimationGroup:^(NSAnimationContext *context) {
         context.duration = kPushAnimationDuration;
         context.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut];


### PR DESCRIPTION
Hello,

I am experimenting with GRPushSegue by porting it to Swift. Works for me!

One thing I noticed was duplication of this line:

``` objective-c
[fromViewController.view addSubview:viewController.view];
```

(see https://github.com/insidegui/GRPushSegue/blob/95d078dcdd2ea6d83daa815506481310a91a1b2d/GRPushSegue/GRPushSegue.m#L25 and https://github.com/insidegui/GRPushSegue/blob/95d078dcdd2ea6d83daa815506481310a91a1b2d/GRPushSegue/GRPushSegue.m#L29)

I believe one of these should be removed. Let me know if that works for you.
